### PR TITLE
Added German translation

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -1,4 +1,5 @@
 # Please keep this file sorted alphabetically.
+de
 en_GB
 it
 ru

--- a/po/de.po
+++ b/po/de.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: Constrict 1.0.1\n"
 "Report-Msgid-Bugs-To: 34974060+Wartybix@users.noreply.github.com\n"
 "POT-Creation-Date: 2025-08-18 13:31-0700\n"
-"PO-Revision-Date: 2025-08-18 14:19-0700\n"
+"PO-Revision-Date: 2025-08-19 10:16+0100\n"
 "Last-Translator: Felicitas Pojtinger <felicitas@pojtinger.com>\n"
 "Language-Team: \n"
 "Language: de\n"
@@ -129,8 +129,8 @@ msgstr "Framerate-Begrenzung"
 msgid ""
 "Limits framerates of compressed videos automatically, or to 30 FPS or 60 FPS."
 msgstr ""
-"Begrenzt Framerates komprimierter Videos automatisch oder auf 30 FPS oder 60 "
-"FPS."
+"Begrenzt Framerates komprimierter Videos automatisch oder auf 30 FPS oder "
+"60 FPS."
 
 #: data/io.github.wartybix.Constrict.gschema.xml.in:38
 msgid "Video Codec"
@@ -165,7 +165,7 @@ msgstr "Felicitas Pojtinger <felicitas@pojtinger.com>"
 #. Please use U+202F Narrow no-break space (' ') between value and unit.
 #: src/window.py:166
 msgid "{} FPS"
-msgstr "{} FPS"
+msgstr "{} FPS"
 
 #. TRANSLATORS: FPS meaning 'frames per second'. {} represents an
 #. integer. Please use U+202F narrow no-break space (' ') between
@@ -176,7 +176,7 @@ msgid ""
 "option set."
 msgstr ""
 "Videos, die auf niedrige Bitraten komprimiert werden, können unabhängig von "
-"der eingestellten Option auf {} FPS begrenzt werden."
+"der eingestellten Option auf {} FPS begrenzt werden."
 
 #. TRANSLATORS: {} represents an integer. Please use U+202F Narrow
 #. no-break space (' ') between {} and '%'.
@@ -191,8 +191,8 @@ msgstr ""
 "Das Verringern der Toleranz maximiert die Bildqualität, indem reduziert "
 "wird, wie weit komprimierte Dateigrößen unter dem Ziel liegen können. Dies "
 "kann jedoch die Anzahl der benötigten Versuche erhöhen, um das Ziel zu "
-"erreichen, und somit die Komprimierungszeit verlängern. Eine Toleranz von {} "
-"% oder mehr wird empfohlen."
+"erreichen, und somit die Komprimierungszeit verlängern. Eine Toleranz von "
+"{} % oder mehr wird empfohlen."
 
 #. TRANSLATORS: {} represents a file size unit (e.g. 'MB')
 #: src/window.py:189
@@ -466,7 +466,7 @@ msgstr "Einstellungen anzeigen"
 #: src/sources_row.py:418
 #, python-brace-format
 msgid "Video compressed to {size} {unit}."
-msgstr "Video auf {size} {unit} komprimiert."
+msgstr "Video auf {size} {unit} komprimiert."
 
 #. TRANSLATORS: {original_size} and {target_size} represent
 #. integers. {unit_original} and {unit_target} represent file
@@ -478,8 +478,8 @@ msgid ""
 "Video file size ({original_size} {unit_original}) already meets the target "
 "size ({target_size} {unit_target})."
 msgstr ""
-"Videodateigröße ({original_size} {unit_original}) entspricht bereits der "
-"Zielgröße ({target_size} {unit_target})."
+"Videodateigröße ({original_size} {unit_original}) entspricht bereits der "
+"Zielgröße ({target_size} {unit_target})."
 
 #. TRANSLATORS: {size} represents an integer. {unit} represents
 #. a file size unit like 'MB'.
@@ -488,7 +488,7 @@ msgstr ""
 #: src/sources_row.py:464
 #, python-brace-format
 msgid "Target size ({size} {unit}) is too low for this file."
-msgstr "Zielgröße ({size} {unit}) ist zu niedrig für diese Datei."
+msgstr "Zielgröße ({size} {unit}) ist zu niedrig für diese Datei."
 
 #: src/sources_row.ui:36 src/sources_row.ui:49 src/sources_row.ui:78
 msgid "View Error Details"
@@ -576,6 +576,7 @@ msgstr "Benutzerdefiniertes Suffix"
 #. error. Please use “” instead of "", if applicable to your
 #. language.
 #: src/error_dialog.py:48
+#, fuzzy
 msgid "There was a problem compressing “{}”"
 msgstr "Es gab ein Problem beim Komprimieren von \\„{}\\\""
 
@@ -628,7 +629,7 @@ msgstr "{res_fps}, {audio_quality} Audio"
 #: src/attempt_fail_box.py:80
 #, python-brace-format
 msgid "{vid_br} {vid_br_unit} ({extra_details})"
-msgstr "{vid_br} {vid_br_unit} ({extra_details})"
+msgstr "{vid_br} {vid_br_unit} ({extra_details})"
 
 #. TRANSLATORS: {size} represents an integer. {unit} represents a
 #. file size unit like 'MB'. Please use U+202F Narrow no-break space
@@ -636,7 +637,7 @@ msgstr "{vid_br} {vid_br_unit} ({extra_details})"
 #: src/attempt_fail_box.py:94
 #, python-brace-format
 msgid "Compressed file size was too large ({size} {unit})"
-msgstr "Komprimierte Dateigröße war zu groß ({size} {unit})"
+msgstr "Komprimierte Dateigröße war zu groß ({size} {unit})"
 
 #. TRANSLATORS: {size} represents an integer. {unit} represents a
 #. file size unit like 'MB'. Please use U+202F Narrow no-break space
@@ -644,7 +645,7 @@ msgstr "Komprimierte Dateigröße war zu groß ({size} {unit})"
 #: src/attempt_fail_box.py:104
 #, python-brace-format
 msgid "Compressed file size was too small ({size} {unit})"
-msgstr "Komprimierte Dateigröße war zu klein ({size} {unit})"
+msgstr "Komprimierte Dateigröße war zu klein ({size} {unit})"
 
 #. TRANSLATORS: {vid_br} represents an integer.
 #. {vid_br_unit} represents a bitrate unit, like 'kbps'.
@@ -655,7 +656,7 @@ msgstr "Komprimierte Dateigröße war zu klein ({size} {unit})"
 #: src/current_attempt_box.py:94
 #, python-brace-format
 msgid "Compressing to {vid_br} {vid_br_unit} ({extra_details})"
-msgstr "Komprimierung auf {vid_br} {vid_br_unit} ({extra_details})"
+msgstr "Komprimierung auf {vid_br} {vid_br_unit} ({extra_details})"
 
 #. TRANSLATORS: {} represents an integer.
 #. Used as part of a larger string, like:
@@ -696,7 +697,7 @@ msgstr[1] "{} Stunden"
 #: src/current_attempt_box.py:168
 #, python-brace-format
 msgid "{percent} % — About {time_shown} left"
-msgstr "{percent} % — Etwa {time_shown} verbleibend"
+msgstr "{percent} % — Etwa {time_shown} verbleibend"
 
 #. TRANSLATORS: please use U+2026 Horizontal ellipsis (…) instead of '...', if applicable to your language.
 #: src/current_attempt_box.ui:26

--- a/po/de.po
+++ b/po/de.po
@@ -576,7 +576,6 @@ msgstr "Benutzerdefiniertes Suffix"
 #. error. Please use “” instead of "", if applicable to your
 #. language.
 #: src/error_dialog.py:48
-#, fuzzy
 msgid "There was a problem compressing “{}”"
 msgstr "Es gab ein Problem beim Komprimieren von „{}“"
 

--- a/po/de.po
+++ b/po/de.po
@@ -86,7 +86,7 @@ msgid ""
 "A choice of codecs to encode output files with, including H.264, HEVC, AV1, "
 "and VP9."
 msgstr ""
-"Auswahl verschiedener Codecs zur Kodierung der Ausgabedateien, "
+"Auswahl verschiedener Codecs zur Codierung der Ausgabedateien, "
 "einschließlich H.264, HEVC, AV1 und VP9."
 
 #: data/io.github.wartybix.Constrict.metainfo.xml.in:20
@@ -138,7 +138,7 @@ msgstr "Video-Codec"
 
 #: data/io.github.wartybix.Constrict.gschema.xml.in:39
 msgid "The codec used to encode with during compression"
-msgstr "Der zur Kodierung während der Komprimierung verwendete Codec"
+msgstr "Der zur Codierung während der Komprimierung verwendete Codec"
 
 #. TRANSLATORS: used in parentheses for the default suffix of exported
 #. files.
@@ -337,7 +337,7 @@ msgstr "Flüssigere Bewegung gewährleisten"
 
 #: src/window.ui:145
 msgid "Encoding Options"
-msgstr "Kodierungsoptionen"
+msgstr "Codierungsoptionen"
 
 #: src/window.ui:148
 msgid "_Video Codec"
@@ -557,12 +557,12 @@ msgstr "Hardware-Beschleunigung"
 #. TRANSLATORS: GPU as in 'graphics processing unit'
 #: src/preferences_dialog.ui:15
 msgid "GPU Encoding"
-msgstr "GPU-Kodierung"
+msgstr "GPU-Codierung"
 
 #. TRANSLATORS: GPU as in 'graphics processing unit'
 #: src/preferences_dialog.ui:17
 msgid "Use the GPU to speed up encoding when available"
-msgstr "GPU zur Beschleunigung der Kodierung verwenden, wenn verfügbar"
+msgstr "GPU zur Beschleunigung der Codierung verwenden, wenn verfügbar"
 
 #: src/preferences_dialog.ui:24
 msgid "Exported Video Suffix"
@@ -578,7 +578,7 @@ msgstr "Benutzerdefiniertes Suffix"
 #: src/error_dialog.py:48
 #, fuzzy
 msgid "There was a problem compressing “{}”"
-msgstr "Es gab ein Problem beim Komprimieren von \\„{}\\\""
+msgstr "Es gab ein Problem beim Komprimieren von „{}“"
 
 #: src/error_dialog.py:70
 msgid "Details copied to clipboard"

--- a/po/de.po
+++ b/po/de.po
@@ -1,0 +1,756 @@
+# German translations for Constrict package.
+# Copyright (C) 2025 Wartybix
+# This file is distributed under the same license as the Constrict package.
+# Automatically generated, 2025.
+# Felicitas Pojtinger <felicitas@pojtinger.com>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Constrict 1.0.1\n"
+"Report-Msgid-Bugs-To: 34974060+Wartybix@users.noreply.github.com\n"
+"POT-Creation-Date: 2025-08-18 13:31-0700\n"
+"PO-Revision-Date: 2025-08-18 14:19-0700\n"
+"Last-Translator: Felicitas Pojtinger <felicitas@pojtinger.com>\n"
+"Language-Team: \n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Gtranslator 48.0\n"
+
+#: data/io.github.wartybix.Constrict.desktop.in:2
+#: data/io.github.wartybix.Constrict.metainfo.xml.in:8 src/main.py:160
+#: src/window.py:318 src/window.ui:6
+msgid "Constrict"
+msgstr "Constrict"
+
+#: data/io.github.wartybix.Constrict.desktop.in:3
+msgid "Video Compressor"
+msgstr "Video-Komprimierer"
+
+#: data/io.github.wartybix.Constrict.desktop.in:4
+#: data/io.github.wartybix.Constrict.metainfo.xml.in:9
+msgid "Compress videos to target sizes"
+msgstr "Videos auf Zielgrößen komprimieren"
+
+#: data/io.github.wartybix.Constrict.desktop.in:10
+msgid "Compress;Video;Movie;Film;Clip;"
+msgstr "Komprimieren;Video;Film;Clip;"
+
+#: data/io.github.wartybix.Constrict.desktop.in:20
+msgid "New Window"
+msgstr "Neues Fenster"
+
+#: data/io.github.wartybix.Constrict.metainfo.xml.in:11
+msgid ""
+"Constrict compresses your videos to your chosen file size — useful for "
+"uploading to services with specific file size limits. No more relying on "
+"online services for video compression, or the manual trial-and-error of re-"
+"encoding at various bitrates yourself."
+msgstr ""
+"Constrict komprimiert Ihre Videos auf die gewünschte Dateigröße — nützlich "
+"zum Hochladen auf Dienste mit spezifischen Dateigrößenbegrenzungen. Keine "
+"Abhängigkeit mehr von Online-Diensten zur Videokomprimierung oder manuelles "
+"Ausprobieren verschiedener Bitraten."
+
+#: data/io.github.wartybix.Constrict.metainfo.xml.in:12
+msgid "Features include:"
+msgstr "Funktionen umfassen:"
+
+#: data/io.github.wartybix.Constrict.metainfo.xml.in:14
+msgid "An intuitive, easy to use interface."
+msgstr "Eine intuitive, benutzerfreundliche Oberfläche."
+
+#: data/io.github.wartybix.Constrict.metainfo.xml.in:15
+msgid ""
+"Automatic calculation of average bitrate (ABR), resolution, framerate, and "
+"audio quality each video is re-encoded with to meet the target file size."
+msgstr ""
+"Automatische Berechnung der durchschnittlichen Bitrate (ABR), Auflösung, "
+"Framerate und Audioqualität für jedes Video, um die Zieldateigröße zu "
+"erreichen."
+
+#: data/io.github.wartybix.Constrict.metainfo.xml.in:16
+msgid "Bulk compression of multiple videos to one output directory."
+msgstr "Massenkomprimierung mehrerer Videos in einen Ausgabeordner."
+
+#: data/io.github.wartybix.Constrict.metainfo.xml.in:17
+msgid ""
+"Customization of framerate limits, to ensure a clearer or smoother image."
+msgstr ""
+"Anpassung der Framerate-Begrenzungen für ein klareres oder flüssigeres Bild."
+
+#: data/io.github.wartybix.Constrict.metainfo.xml.in:18
+msgid ""
+"A choice of codecs to encode output files with, including H.264, HEVC, AV1, "
+"and VP9."
+msgstr ""
+"Auswahl verschiedener Codecs zur Kodierung der Ausgabedateien, "
+"einschließlich H.264, HEVC, AV1 und VP9."
+
+#: data/io.github.wartybix.Constrict.metainfo.xml.in:20
+msgid ""
+"The app attempts to retain as much audiovisual quality as possible for the "
+"file size given. However, extremely steep reductions in file size can cause "
+"significant loss of quality in the output file, and sometimes compression "
+"may not be possible at all. All processing is done locally — and as such, "
+"compression speeds are only as fast as your hardware allows."
+msgstr ""
+"Die App versucht, so viel audiovisuelle Qualität wie möglich für die "
+"gegebene Dateigröße zu erhalten. Jedoch können extrem starke Reduzierungen "
+"der Dateigröße zu erheblichem Qualitätsverlust in der Ausgabedatei führen, "
+"und manchmal ist eine Komprimierung überhaupt nicht möglich. Die gesamte "
+"Verarbeitung erfolgt lokal — daher sind die Komprimierungsgeschwindigkeiten "
+"nur so schnell, wie Ihre Hardware es erlaubt."
+
+#: data/io.github.wartybix.Constrict.metainfo.xml.in:75
+msgid "Source videos queued for compression"
+msgstr "Quellvideos in der Warteschlange zur Komprimierung"
+
+#: data/io.github.wartybix.Constrict.metainfo.xml.in:79
+msgid "The application mid-compression"
+msgstr "Die Anwendung während der Komprimierung"
+
+#: data/io.github.wartybix.Constrict.metainfo.xml.in:83
+msgid "A mobile friendly UI"
+msgstr "Eine mobilfreundliche Benutzeroberfläche"
+
+#: data/io.github.wartybix.Constrict.metainfo.xml.in:87
+msgid "Compression settings in the mobile friendly UI"
+msgstr ""
+"Komprimierungseinstellungen in der mobilfreundlichen Benutzeroberfläche"
+
+#: data/io.github.wartybix.Constrict.gschema.xml.in:31 src/window.ui:78
+msgid "Framerate Limit"
+msgstr "Framerate-Begrenzung"
+
+#: data/io.github.wartybix.Constrict.gschema.xml.in:32
+msgid ""
+"Limits framerates of compressed videos automatically, or to 30 FPS or 60 FPS."
+msgstr ""
+"Begrenzt Framerates komprimierter Videos automatisch oder auf 30 FPS oder 60 "
+"FPS."
+
+#: data/io.github.wartybix.Constrict.gschema.xml.in:38
+msgid "Video Codec"
+msgstr "Video-Codec"
+
+#: data/io.github.wartybix.Constrict.gschema.xml.in:39
+msgid "The codec used to encode with during compression"
+msgstr "Der zur Kodierung während der Komprimierung verwendete Codec"
+
+#. TRANSLATORS: used in parentheses for the default suffix of exported
+#. files.
+#: src/main.py:81
+msgid "compressed"
+msgstr "komprimiert"
+
+#. TRANSLATORS: Braces represent the name of the repository (e.g. 8mb)
+#. Please use ‘’ characters instead of '', if applicable to your language.
+#: src/main.py:173
+msgid "‘{}’ repository by"
+msgstr "„{}“-Repository von"
+
+#: src/main.py:180
+msgid "Circular progress indicator (C version) by"
+msgstr "Kreisförmiger Fortschrittsanzeiger (C-Version) von"
+
+#: src/main.py:184
+msgid "translator-credits"
+msgstr "Felicitas Pojtinger <felicitas@pojtinger.com>"
+
+#. TRANSLATORS: 'FPS' meaning 'frames per second'.
+#. {} represents the FPS value, for example 30 or 60.
+#. Please use U+202F Narrow no-break space (' ') between value and unit.
+#: src/window.py:166
+msgid "{} FPS"
+msgstr "{} FPS"
+
+#. TRANSLATORS: FPS meaning 'frames per second'. {} represents an
+#. integer. Please use U+202F narrow no-break space (' ') between
+#. the {} and translated equivalent of 'FPS'.
+#: src/window.py:175
+msgid ""
+"Videos compressed to low bitrates may be capped to {} FPS, regardless of the "
+"option set."
+msgstr ""
+"Videos, die auf niedrige Bitraten komprimiert werden, können unabhängig von "
+"der eingestellten Option auf {} FPS begrenzt werden."
+
+#. TRANSLATORS: {} represents an integer. Please use U+202F Narrow
+#. no-break space (' ') between {} and '%'.
+#: src/window.py:184
+#, python-format
+msgid ""
+"Decreasing the tolerance maximizes image quality by reducing how much "
+"compressed file sizes can be under target. However, this can increase the "
+"number of attempts needed to meet the target, increasing compression time. A "
+"tolerance of {} % or more is recommended."
+msgstr ""
+"Das Verringern der Toleranz maximiert die Bildqualität, indem reduziert "
+"wird, wie weit komprimierte Dateigrößen unter dem Ziel liegen können. Dies "
+"kann jedoch die Anzahl der benötigten Versuche erhöhen, um das Ziel zu "
+"erreichen, und somit die Komprimierungszeit verlängern. Eine Toleranz von {} "
+"% oder mehr wird empfohlen."
+
+#. TRANSLATORS: {} represents a file size unit (e.g. 'MB')
+#: src/window.py:189
+msgid "Target _Size ({})"
+msgstr "Ziel_größe ({})"
+
+#. TRANSLATORS: {} represents the filename of the video currently
+#. being processed. Please use “” instead of "", if applicable to
+#. your language.
+#: src/window.py:291
+msgid "Processing “{}”"
+msgstr "„{}“ wird verarbeitet"
+
+#. TRANSLATORS: {index} represents the index of the video
+#. currently being processed. {total} represents the total
+#. number of videos being processed.
+#: src/window.py:297
+#, python-brace-format
+msgid "{index}/{total} Videos Processed"
+msgstr "{index}/{total} Videos verarbeitet"
+
+#. TRANSLATORS: {} represents the path of the directory being
+#. exported to. Please use “” instead of "", if applicable to your
+#. language.
+#: src/window.py:308
+msgid "Exporting to “{}”"
+msgstr "Export nach „{}“"
+
+#. TRANSLATORS: {} represents the filename of the video currently
+#. queued. Please use “” instead of '', if applicable to your
+#. language.
+#: src/window.py:324
+msgid "“{}” Queued"
+msgstr "„{}“ in Warteschlange"
+
+#. TRANSLATORS: {} represents the number of files queued.
+#: src/window.py:328
+msgid "{} Videos Queued"
+msgstr "{} Videos in Warteschlange"
+
+#: src/window.py:459
+msgid "Stop Compression?"
+msgstr "Komprimierung stoppen?"
+
+#. TRANSLATORS: {} represents the filename of the video currently
+#. being compressed. Please use “” instead of "", if applicable to
+#. your language.
+#: src/window.py:463
+msgid "Progress made compressing “{}” will be permanently lost"
+msgstr ""
+"Der Fortschritt bei der Komprimierung von „{}“ wird dauerhaft verloren gehen"
+
+#: src/window.py:469
+msgid "_Cancel"
+msgstr "_Abbrechen"
+
+#: src/window.py:470
+msgid "_Stop"
+msgstr "_Stoppen"
+
+#: src/window.py:524 src/window.py:763
+msgid "Compression Complete"
+msgstr "Komprimierung abgeschlossen"
+
+#. TRANSLATORS: {} represents the filename of the video that has
+#. been processed.
+#. Please use “” instead of "", if applicable to your language.
+#: src/window.py:532
+msgid "“{}” processed"
+msgstr "„{}“ verarbeitet"
+
+#. TRANSLATORS: {} represents the number of files that have been
+#. processed.
+#: src/window.py:537
+msgid "{} files processed"
+msgstr "{} Dateien verarbeitet"
+
+#: src/window.py:548
+msgid "Open Export Directory"
+msgstr "Export-Ordner öffnen"
+
+#: src/window.py:605
+msgid "Videos are being compressed"
+msgstr "Videos werden komprimiert"
+
+#. TRANSLATORS: please use U+2026 Horizontal ellipsis (…)
+#. instead of '...', if applicable to your language
+#: src/window.py:627
+msgid "Analyzing…"
+msgstr "Analysiert…"
+
+#. TRANSLATORS: {} represents the filename of the video with
+#. the error. Please use “” instead of "", if applicable to
+#. your language.
+#: src/window.py:722
+msgid "Error compressing “{}”"
+msgstr "Fehler beim Komprimieren von „{}“"
+
+#: src/window.py:725
+msgid "View _Details"
+msgstr "_Details anzeigen"
+
+#: src/window.py:759
+msgid "Compression Canceled"
+msgstr "Komprimierung abgebrochen"
+
+#: src/window.py:845
+msgid "Videos"
+msgstr "Videos"
+
+#: src/window.py:848
+msgid "Pick Videos"
+msgstr "Videos auswählen"
+
+#: src/window.ui:26
+msgid "Toggle Settings Pane"
+msgstr "Einstellungsbereich umschalten"
+
+#: src/window.ui:34
+msgid "Main Menu"
+msgstr "Hauptmenü"
+
+#: src/window.ui:82 src/window.ui:194 src/preferences_dialog.ui:27
+msgid "More Information"
+msgstr "Weitere Informationen"
+
+#: src/window.ui:107
+msgid "_Automatic"
+msgstr "_Automatisch"
+
+#: src/window.ui:109
+msgid "Use the highest framerate without sacrificing resolution"
+msgstr "Höchste Framerate ohne Qualitätseinbußen bei der Auflösung verwenden"
+
+#: src/window.ui:121
+msgid "Ensure higher image clarity"
+msgstr "Höhere Bildschärfe gewährleisten"
+
+#: src/window.ui:133
+msgid "Ensure smoother motion"
+msgstr "Flüssigere Bewegung gewährleisten"
+
+#: src/window.ui:145
+msgid "Encoding Options"
+msgstr "Kodierungsoptionen"
+
+#: src/window.ui:148
+msgid "_Video Codec"
+msgstr "_Video-Codec"
+
+#: src/window.ui:164
+msgid "Extra _Quality"
+msgstr "Extra _Qualität"
+
+#: src/window.ui:166
+msgid "Increase image quality at the cost of compression time"
+msgstr "Bildqualität auf Kosten der Komprimierungszeit erhöhen"
+
+#: src/window.ui:173
+msgid "Advanced Options"
+msgstr "Erweiterte Optionen"
+
+#: src/window.ui:176
+msgid "_Tolerance (%)"
+msgstr "_Toleranz (%)"
+
+#: src/window.ui:178
+msgid "How far end file sizes can be below target"
+msgstr "Wie weit die endgültige Dateigröße unter dem Ziel liegen darf"
+
+#: src/window.ui:230
+msgid "Compress Videos"
+msgstr "Videos komprimieren"
+
+#: src/window.ui:231
+msgid "Drag and drop videos here"
+msgstr "Videos hier hineinziehen"
+
+#. TRANSLATORS: please use U+2026 Horizontal ellipsis (…) instead of '...', if applicable to your language
+#: src/window.ui:235
+msgid "_Open…"
+msgstr "Ö_ffnen…"
+
+#. TRANSLATORS: Please use U+2014 em dash ('—') instead of '-', if applicable to your language.
+#: src/window.ui:258
+msgid "Issues with video sources — fix before compressing"
+msgstr "Probleme mit Videoquellen — vor der Komprimierung beheben"
+
+#: src/window.ui:278
+msgid "Video Sources"
+msgstr "Videoquellen"
+
+#: src/window.ui:281
+msgid "_Clear All"
+msgstr "Alle _löschen"
+
+#. TRANSLATORS: please use U+2026 Horizontal ellipsis (…) instead of '...', if applicable to your language
+#: src/window.ui:308
+msgid "_Export To…"
+msgstr "_Exportieren nach…"
+
+#. TRANSLATORS: please use U+2026 Horizontal ellipsis (…) instead of '...', if applicable to your language
+#: src/window.ui:328
+msgid "_Cancel…"
+msgstr "_Abbrechen…"
+
+#: src/window.ui:357
+msgid "_New Window"
+msgstr "_Neues Fenster"
+
+#: src/window.ui:363
+msgid "_Preferences"
+msgstr "_Einstellungen"
+
+#: src/window.ui:367
+msgid "_Keyboard Shortcuts"
+msgstr "_Tastenkürzel"
+
+#: src/window.ui:371
+msgid "_About Constrict"
+msgstr "_Über Constrict"
+
+#: src/gtk/help-overlay.ui:11
+msgctxt "shortcut window"
+msgid "Video Management"
+msgstr "Videoverwaltung"
+
+#: src/gtk/help-overlay.ui:14
+msgctxt "shortcut window"
+msgid "Open"
+msgstr "Öffnen"
+
+#: src/gtk/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Export"
+msgstr "Exportieren"
+
+#: src/gtk/help-overlay.ui:28
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Allgemein"
+
+#: src/gtk/help-overlay.ui:31
+msgctxt "shortcut window"
+msgid "Toggle Settings Pane"
+msgstr "Einstellungsbereich umschalten"
+
+#: src/gtk/help-overlay.ui:37
+msgctxt "shortcut window"
+msgid "Show Shortcuts"
+msgstr "Tastenkürzel anzeigen"
+
+#: src/gtk/help-overlay.ui:43
+msgctxt "shortcut window"
+msgid "Close Window"
+msgstr "Fenster schließen"
+
+#: src/gtk/help-overlay.ui:49
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Beenden"
+
+#: src/gtk/help-overlay.ui:55
+msgctxt "shortcut window"
+msgid "Show Preferences"
+msgstr "Einstellungen anzeigen"
+
+#. TRANSLATORS: {size} represents a file size value in MB.
+#. {unit} represents a file size unit, like 'MB'. Please use U+202F
+#. narrow no-break space (' ') between size and unit.
+#: src/sources_row.py:418
+#, python-brace-format
+msgid "Video compressed to {size} {unit}."
+msgstr "Video auf {size} {unit} komprimiert."
+
+#. TRANSLATORS: {original_size} and {target_size} represent
+#. integers. {unit_original} and {unit_target} represent file
+#. size units, like 'MB'. Please use U+202F Narrow no-break
+#. space (' ') between values and units.
+#: src/sources_row.py:444
+#, python-brace-format
+msgid ""
+"Video file size ({original_size} {unit_original}) already meets the target "
+"size ({target_size} {unit_target})."
+msgstr ""
+"Videodateigröße ({original_size} {unit_original}) entspricht bereits der "
+"Zielgröße ({target_size} {unit_target})."
+
+#. TRANSLATORS: {size} represents an integer. {unit} represents
+#. a file size unit like 'MB'.
+#. Please use U+202F Narrow no-break space (' ') between value
+#. and unit.
+#: src/sources_row.py:464
+#, python-brace-format
+msgid "Target size ({size} {unit}) is too low for this file."
+msgstr "Zielgröße ({size} {unit}) ist zu niedrig für diese Datei."
+
+#: src/sources_row.ui:36 src/sources_row.ui:49 src/sources_row.ui:78
+msgid "View Error Details"
+msgstr "Fehlerdetails anzeigen"
+
+#: src/sources_row.ui:56
+msgid "Cannot load video. It may be missing or corrupted."
+msgstr ""
+"Video kann nicht geladen werden. Es fehlt möglicherweise oder ist beschädigt."
+
+#: src/sources_row.ui:106
+msgid "View Compression Progress"
+msgstr "Komprimierungsfortschritt anzeigen"
+
+#: src/sources_row.ui:143
+msgid "More Details"
+msgstr "Weitere Details"
+
+#: src/sources_row.ui:164
+msgid "Show File Location"
+msgstr "Dateispeicherort anzeigen"
+
+#: src/sources_row.ui:181
+msgid "View More"
+msgstr "Mehr anzeigen"
+
+#: src/sources_row.ui:210
+msgid "Move _Up"
+msgstr "Nach _oben"
+
+#: src/sources_row.ui:214
+msgid "Move _Down"
+msgstr "Nach _unten"
+
+#: src/sources_row.ui:220
+msgid "_Remove"
+msgstr "_Entfernen"
+
+#. TRANSLATORS: please use U+2026 Horizontal ellipsis (…) instead of '...', if applicable to your language
+#: src/sources_list_box.ui:11
+msgid "Add Vide_os…"
+msgstr "Vide_os hinzufügen…"
+
+#. TRANSLATORS: {} represents the value of the default suffix.
+#: src/preferences_dialog.py:42
+msgid ""
+"Used in file names for exported videos, between the base name and extension. "
+"If the custom suffix is left empty, the default suffix of “{}” will be used."
+msgstr ""
+"Wird in Dateinamen für exportierte Videos verwendet, zwischen dem Basisnamen "
+"und der Erweiterung. Wenn das benutzerdefinierte Suffix leer gelassen wird, "
+"wird das Standardsuffix „{}“ verwendet."
+
+#: src/preferences_dialog.py:64
+msgid "Changes applied"
+msgstr "Änderungen angewendet"
+
+#: src/preferences_dialog.ui:6
+msgid "Preferences"
+msgstr "Einstellungen"
+
+#: src/preferences_dialog.ui:11
+msgid "Hardware Acceleration"
+msgstr "Hardware-Beschleunigung"
+
+#. TRANSLATORS: GPU as in 'graphics processing unit'
+#: src/preferences_dialog.ui:15
+msgid "GPU Encoding"
+msgstr "GPU-Kodierung"
+
+#. TRANSLATORS: GPU as in 'graphics processing unit'
+#: src/preferences_dialog.ui:17
+msgid "Use the GPU to speed up encoding when available"
+msgstr "GPU zur Beschleunigung der Kodierung verwenden, wenn verfügbar"
+
+#: src/preferences_dialog.ui:24
+msgid "Exported Video Suffix"
+msgstr "Exportiertes Video-Suffix"
+
+#: src/preferences_dialog.ui:52
+msgid "Custom Suffix"
+msgstr "Benutzerdefiniertes Suffix"
+
+#. TRANSLATORS: {} represents the filename of the video with the
+#. error. Please use “” instead of "", if applicable to your
+#. language.
+#: src/error_dialog.py:48
+msgid "There was a problem compressing “{}”"
+msgstr "Es gab ein Problem beim Komprimieren von \\„{}\\\""
+
+#: src/error_dialog.py:70
+msgid "Details copied to clipboard"
+msgstr "Details in Zwischenablage kopiert"
+
+#: src/error_dialog.ui:8
+msgid "Compression Error"
+msgstr "Komprimierungsfehler"
+
+#: src/error_dialog.ui:22
+msgid "Details"
+msgstr "Details"
+
+#: src/error_dialog.ui:25
+msgid "Copy Details"
+msgstr "Details kopieren"
+
+#. TRANSLATORS: {} represents the attempt number.
+#: src/attempt_fail_box.py:52 src/current_attempt_box.py:42
+#: src/current_attempt_box.py:66
+msgid "Attempt {}"
+msgstr "Versuch {}"
+
+#. TRANSLATORS: this is an abbreviation of 'High Quality'
+#: src/attempt_fail_box.py:55 src/current_attempt_box.py:70
+msgid "HQ"
+msgstr "HQ"
+
+#. TRANSLATORS: this is an abbreviation of 'Low Quality'
+#: src/attempt_fail_box.py:58 src/current_attempt_box.py:73
+msgid "LQ"
+msgstr "LQ"
+
+#. TRANSLATORS:
+#. {res_fps} represents a resolution + framerate (e.g. '1080p@30').
+#. {audio_quality} represents audio quality (i.e. 'HQ' or 'LQ').
+#: src/attempt_fail_box.py:68 src/current_attempt_box.py:83
+#, python-brace-format
+msgid "{res_fps}, {audio_quality} audio"
+msgstr "{res_fps}, {audio_quality} Audio"
+
+#. TRANSLATORS: {vid_br} represents an integer.
+#. {vid_br_unit} represents a bitrate unit, like 'kbps'.
+#. {extra_details} will either display resolution/FPS and audio quality
+#. details, or just resolution/FPS if the video has no audio streams.
+#. Please use U+202F Narrow no-break space (' ') between video bitrate
+#. and unit.
+#: src/attempt_fail_box.py:80
+#, python-brace-format
+msgid "{vid_br} {vid_br_unit} ({extra_details})"
+msgstr "{vid_br} {vid_br_unit} ({extra_details})"
+
+#. TRANSLATORS: {size} represents an integer. {unit} represents a
+#. file size unit like 'MB'. Please use U+202F Narrow no-break space
+#. (' ') between size and unit.
+#: src/attempt_fail_box.py:94
+#, python-brace-format
+msgid "Compressed file size was too large ({size} {unit})"
+msgstr "Komprimierte Dateigröße war zu groß ({size} {unit})"
+
+#. TRANSLATORS: {size} represents an integer. {unit} represents a
+#. file size unit like 'MB'. Please use U+202F Narrow no-break space
+#. (' ') between size and unit.
+#: src/attempt_fail_box.py:104
+#, python-brace-format
+msgid "Compressed file size was too small ({size} {unit})"
+msgstr "Komprimierte Dateigröße war zu klein ({size} {unit})"
+
+#. TRANSLATORS: {vid_br} represents an integer.
+#. {vid_br_unit} represents a bitrate unit, like 'kbps'.
+#. {extra_details} will either display resolution/FPS and audio quality
+#. details, or just resolution/FPS if the video has no audio streams.
+#. Please use U+202F Narrow no-break space (' ') between video bitrate
+#. and unit.
+#: src/current_attempt_box.py:94
+#, python-brace-format
+msgid "Compressing to {vid_br} {vid_br_unit} ({extra_details})"
+msgstr "Komprimierung auf {vid_br} {vid_br_unit} ({extra_details})"
+
+#. TRANSLATORS: {} represents an integer.
+#. Used as part of a larger string, like:
+#. '5% -- About 30 seconds left'
+#: src/current_attempt_box.py:129
+msgid "{} second"
+msgid_plural "{} seconds"
+msgstr[0] "{} Sekunde"
+msgstr[1] "{} Sekunden"
+
+#. TRANSLATORS: {} represents an integer.
+#. Used as part of a larger string, like:
+#. '10% -- About 30 minutes left'
+#. TRANSLATORS: {} represents an integer. Used as part of a
+#. larger string, like:
+#. '10% -- About 2 hours, 30 minutes left'
+#: src/current_attempt_box.py:137 src/current_attempt_box.py:150
+msgid "{} minute"
+msgid_plural "{} minutes"
+msgstr[0] "{} Minute"
+msgstr[1] "{} Minuten"
+
+#. TRANSLATORS: {} represents an integer. Used as part of a
+#. larger string, like:
+#. '10% -- About 2 hours, 30 minutes left'
+#: src/current_attempt_box.py:145 src/current_attempt_box.py:159
+msgid "{} hour"
+msgid_plural "{} hours"
+msgstr[0] "{} Stunde"
+msgstr[1] "{} Stunden"
+
+#. TRANSLATORS: {percent} represents the progress percentage value.
+#. {time_shown} represents a string showing the estimated time to
+#. completion (like '50 minutes').
+#. Please use U+202F Narrow no-break space (' ') between {percent}
+#. and '%'.
+#. Please use U+2014 em dash ('—'), if applicable to your language.
+#: src/current_attempt_box.py:168
+#, python-brace-format
+msgid "{percent} % — About {time_shown} left"
+msgstr "{percent} % — Etwa {time_shown} verbleibend"
+
+#. TRANSLATORS: please use U+2026 Horizontal ellipsis (…) instead of '...', if applicable to your language.
+#: src/current_attempt_box.ui:26
+msgid "Initializing…"
+msgstr "Initialisiert…"
+
+#: src/constrict_utils.py:754
+msgid ""
+"Constrict: Could not read input file. Was it moved or deleted before "
+"compression?"
+msgstr ""
+"Constrict: Eingabedatei konnte nicht gelesen werden. Wurde sie vor der "
+"Komprimierung verschoben oder gelöscht?"
+
+#: src/constrict_utils.py:761
+msgid "Constrict: File already meets the target size."
+msgstr "Constrict: Datei entspricht bereits der Zielgröße."
+
+#: src/constrict_utils.py:772
+msgid ""
+"Constrict: Could not retrieve video properties. Source video may be missing "
+"or corrupted."
+msgstr ""
+"Constrict: Videoeigenschaften konnten nicht abgerufen werden. Das Quellvideo "
+"fehlt möglicherweise oder ist beschädigt."
+
+#: src/constrict_utils.py:779
+msgid ""
+"Constrict: Could not create exported file. A file with the reserved name "
+"already exists."
+msgstr ""
+"Constrict: Exportierte Datei konnte nicht erstellt werden. Eine Datei mit "
+"dem reservierten Namen existiert bereits."
+
+#: src/constrict_utils.py:781
+msgid ""
+"Constrict: Could not create exported file. There are insufficient "
+"permissions to create a file at the requested export path."
+msgstr ""
+"Constrict: Exportierte Datei konnte nicht erstellt werden. Es sind "
+"unzureichende Berechtigungen vorhanden, um eine Datei im angeforderten "
+"Exportpfad zu erstellen."
+
+#: src/constrict_utils.py:846
+msgid ""
+"Constrict: Video bitrate got too low (<5 kbps). The target size may be too "
+"low for this file."
+msgstr ""
+"Constrict: Video-Bitrate wurde zu niedrig (<5 kbps). Die Zielgröße ist "
+"möglicherweise zu niedrig für diese Datei."
+
+#: src/constrict_utils.py:886
+msgid ""
+"Constrict: Cannot read output file. Was it moved or deleted mid-compression?"
+msgstr ""
+"Constrict: Ausgabedatei kann nicht gelesen werden. Wurde sie während der "
+"Komprimierung verschoben oder gelöscht?"


### PR DESCRIPTION
This adds a full German translation of Constrict. I hope I did this right - usually I use Weblate :sweat_smile: 

Preview:

<img width="2244" height="1644" alt="Constrict translated to German (Constrict in Deutsch übersetzt)" src="https://github.com/user-attachments/assets/0235ec0b-724d-49f9-b668-fdafeb11a878" />
